### PR TITLE
Vendor deps update

### DIFF
--- a/src/main/java/frc/robot/constants/TunerConstants.java
+++ b/src/main/java/frc/robot/constants/TunerConstants.java
@@ -3,17 +3,14 @@ package frc.robot.constants;
 import static edu.wpi.first.units.Units.*;
 
 import com.ctre.phoenix6.CANBus;
-import com.ctre.phoenix6.configs.CANcoderConfiguration;
-import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
-import com.ctre.phoenix6.configs.Pigeon2Configuration;
-import com.ctre.phoenix6.configs.Slot0Configs;
-import com.ctre.phoenix6.configs.TalonFXConfiguration;
-import com.ctre.phoenix6.signals.StaticFeedforwardSignValue;
-import com.ctre.phoenix6.swerve.SwerveDrivetrainConstants;
-import com.ctre.phoenix6.swerve.SwerveModuleConstants;
-import com.ctre.phoenix6.swerve.SwerveModuleConstants.ClosedLoopOutputType;
-import com.ctre.phoenix6.swerve.SwerveModuleConstants.SteerFeedbackType;
-import com.ctre.phoenix6.swerve.SwerveModuleConstantsFactory;
+import com.ctre.phoenix6.configs.*;
+import com.ctre.phoenix6.hardware.*;
+import com.ctre.phoenix6.signals.*;
+import com.ctre.phoenix6.swerve.*;
+import com.ctre.phoenix6.swerve.SwerveModuleConstants.*;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.units.measure.*;
 import frc.robot.subsystems.drivetrain.CommandSwerveDrivetrain;
 
@@ -31,7 +28,7 @@ public class TunerConstants {
           .withKI(0)
           .withKD(0.5)
           .withKS(0.1)
-          .withKV(1.59)
+          .withKV(1.91)
           .withKA(0)
           .withStaticFeedforwardSign(StaticFeedforwardSignValue.UseClosedLoopSign);
   // When using closed-loop control, the drive motor uses the control
@@ -46,6 +43,13 @@ public class TunerConstants {
   // This affects the PID/FF gains for the drive motors
   private static final ClosedLoopOutputType kDriveClosedLoopOutput = ClosedLoopOutputType.Voltage;
 
+  // The type of motor used for the drive motor
+  private static final DriveMotorArrangement kDriveMotorType =
+      DriveMotorArrangement.TalonFX_Integrated;
+  // The type of motor used for the drive motor
+  private static final SteerMotorArrangement kSteerMotorType =
+      SteerMotorArrangement.TalonFX_Integrated;
+
   // The remote sensor feedback type to use for the steer motors;
   // When not Pro-licensed, FusedCANcoder/SyncCANcoder automatically fall back to
   // RemoteCANcoder
@@ -55,8 +59,8 @@ public class TunerConstants {
   // This needs to be tuned to your individual robot
   private static final Current kSlipCurrent = Amps.of(120.0);
 
-  // Initial configs for the drive and steer motors and the CANcoder; these cannot
-  // be null.
+  // Initial configs for the drive and steer motors and the azimuth encoder; these
+  // cannot be null.
   // Some configs will be overwritten; check the `with*InitialConfigs()` API
   // documentation.
   private static final TalonFXConfiguration driveInitialConfigs = new TalonFXConfiguration();
@@ -69,24 +73,24 @@ public class TunerConstants {
                   // stator current limit to help avoid brownouts without impacting performance.
                   .withStatorCurrentLimit(Amps.of(60))
                   .withStatorCurrentLimitEnable(true));
-  private static final CANcoderConfiguration cancoderInitialConfigs = new CANcoderConfiguration();
+  private static final CANcoderConfiguration encoderInitialConfigs = new CANcoderConfiguration();
   // Configs for the Pigeon 2; leave this null to skip applying Pigeon 2 configs
   private static final Pigeon2Configuration pigeonConfigs = null;
 
   // CAN bus that the devices are located on;
   // All swerve devices must share the same CAN bus
-  public static final CANBus kCANBus = new CANBus("rio", "./logs/example.hoot");
+  public static final CANBus kCANBus = new CANBus("canivore", "./logs/example.hoot");
 
   // Theoretical free speed (m/s) at 12 V applied output;
   // This needs to be tuned to your individual robot
-  public static final LinearVelocity kSpeedAt12Volts = MetersPerSecond.of(4.55);
+  public static final LinearVelocity kSpeedAt12Volts = MetersPerSecond.of(4.69);
 
   // Every 1 rotation of the azimuth results in kCoupleRatio drive motor turns;
   // This may need to be tuned to your individual robot
-  private static final double kCoupleRatio = 3.5;
+  private static final double kCoupleRatio = 3.8181818181818183;
 
-  private static final double kDriveGearRatio = 7.363636364;
-  private static final double kSteerGearRatio = 12.8;
+  private static final double kDriveGearRatio = 7.363636363636365;
+  private static final double kSteerGearRatio = 15.42857142857143;
   private static final Distance kWheelRadius = Inches.of(2.167);
 
   private static final boolean kInvertLeftSide = false;
@@ -107,115 +111,128 @@ public class TunerConstants {
           .withPigeon2Id(kPigeonId)
           .withPigeon2Configs(pigeonConfigs);
 
-  private static final SwerveModuleConstantsFactory ConstantCreator =
-      new SwerveModuleConstantsFactory()
-          .withDriveMotorGearRatio(kDriveGearRatio)
-          .withSteerMotorGearRatio(kSteerGearRatio)
-          .withCouplingGearRatio(kCoupleRatio)
-          .withWheelRadius(kWheelRadius)
-          .withSteerMotorGains(steerGains)
-          .withDriveMotorGains(driveGains)
-          .withSteerMotorClosedLoopOutput(kSteerClosedLoopOutput)
-          .withDriveMotorClosedLoopOutput(kDriveClosedLoopOutput)
-          .withSlipCurrent(kSlipCurrent)
-          .withSpeedAt12Volts(kSpeedAt12Volts)
-          .withFeedbackSource(kSteerFeedbackType)
-          .withDriveMotorInitialConfigs(driveInitialConfigs)
-          .withSteerMotorInitialConfigs(steerInitialConfigs)
-          .withCANcoderInitialConfigs(cancoderInitialConfigs)
-          .withSteerInertia(kSteerInertia)
-          .withDriveInertia(kDriveInertia)
-          .withSteerFrictionVoltage(kSteerFrictionVoltage)
-          .withDriveFrictionVoltage(kDriveFrictionVoltage);
+  private static final SwerveModuleConstantsFactory<
+          TalonFXConfiguration, TalonFXConfiguration, CANcoderConfiguration>
+      ConstantCreator =
+          new SwerveModuleConstantsFactory<
+                  TalonFXConfiguration, TalonFXConfiguration, CANcoderConfiguration>()
+              .withDriveMotorGearRatio(kDriveGearRatio)
+              .withSteerMotorGearRatio(kSteerGearRatio)
+              .withCouplingGearRatio(kCoupleRatio)
+              .withWheelRadius(kWheelRadius)
+              .withSteerMotorGains(steerGains)
+              .withDriveMotorGains(driveGains)
+              .withSteerMotorClosedLoopOutput(kSteerClosedLoopOutput)
+              .withDriveMotorClosedLoopOutput(kDriveClosedLoopOutput)
+              .withSlipCurrent(kSlipCurrent)
+              .withSpeedAt12Volts(kSpeedAt12Volts)
+              .withDriveMotorType(kDriveMotorType)
+              .withSteerMotorType(kSteerMotorType)
+              .withFeedbackSource(kSteerFeedbackType)
+              .withDriveMotorInitialConfigs(driveInitialConfigs)
+              .withSteerMotorInitialConfigs(steerInitialConfigs)
+              .withEncoderInitialConfigs(encoderInitialConfigs)
+              .withSteerInertia(kSteerInertia)
+              .withDriveInertia(kDriveInertia)
+              .withSteerFrictionVoltage(kSteerFrictionVoltage)
+              .withDriveFrictionVoltage(kDriveFrictionVoltage);
 
   // Front Left
-  private static final int kFrontLeftDriveMotorId = 5;
-  private static final int kFrontLeftSteerMotorId = 4;
-  private static final int kFrontLeftEncoderId = 2;
-  private static final Angle kFrontLeftEncoderOffset = Rotations.of(-0.83544921875);
+  private static final int kFrontLeftDriveMotorId = 3;
+  private static final int kFrontLeftSteerMotorId = 2;
+  private static final int kFrontLeftEncoderId = 1;
+  private static final Angle kFrontLeftEncoderOffset = Rotations.of(0.15234375);
   private static final boolean kFrontLeftSteerMotorInverted = true;
-  private static final boolean kFrontLeftCANcoderInverted = false;
+  private static final boolean kFrontLeftEncoderInverted = false;
 
-  private static final Distance kFrontLeftXPos = Inches.of(10.5);
-  private static final Distance kFrontLeftYPos = Inches.of(10.5);
+  private static final Distance kFrontLeftXPos = Inches.of(10);
+  private static final Distance kFrontLeftYPos = Inches.of(10);
 
   // Front Right
-  private static final int kFrontRightDriveMotorId = 7;
-  private static final int kFrontRightSteerMotorId = 6;
-  private static final int kFrontRightEncoderId = 3;
-  private static final Angle kFrontRightEncoderOffset = Rotations.of(-0.15234375);
+  private static final int kFrontRightDriveMotorId = 1;
+  private static final int kFrontRightSteerMotorId = 0;
+  private static final int kFrontRightEncoderId = 0;
+  private static final Angle kFrontRightEncoderOffset = Rotations.of(-0.4873046875);
   private static final boolean kFrontRightSteerMotorInverted = true;
-  private static final boolean kFrontRightCANcoderInverted = false;
+  private static final boolean kFrontRightEncoderInverted = false;
 
-  private static final Distance kFrontRightXPos = Inches.of(10.5);
-  private static final Distance kFrontRightYPos = Inches.of(-10.5);
+  private static final Distance kFrontRightXPos = Inches.of(10);
+  private static final Distance kFrontRightYPos = Inches.of(-10);
 
   // Back Left
-  private static final int kBackLeftDriveMotorId = 1;
-  private static final int kBackLeftSteerMotorId = 0;
-  private static final int kBackLeftEncoderId = 0;
-  private static final Angle kBackLeftEncoderOffset = Rotations.of(-0.4794921875);
+  private static final int kBackLeftDriveMotorId = 7;
+  private static final int kBackLeftSteerMotorId = 6;
+  private static final int kBackLeftEncoderId = 3;
+  private static final Angle kBackLeftEncoderOffset = Rotations.of(-0.219482421875);
   private static final boolean kBackLeftSteerMotorInverted = true;
-  private static final boolean kBackLeftCANcoderInverted = false;
+  private static final boolean kBackLeftEncoderInverted = false;
 
-  private static final Distance kBackLeftXPos = Inches.of(-10.5);
-  private static final Distance kBackLeftYPos = Inches.of(10.5);
+  private static final Distance kBackLeftXPos = Inches.of(-10);
+  private static final Distance kBackLeftYPos = Inches.of(10);
 
   // Back Right
-  private static final int kBackRightDriveMotorId = 3;
-  private static final int kBackRightSteerMotorId = 2;
-  private static final int kBackRightEncoderId = 1;
-  private static final Angle kBackRightEncoderOffset = Rotations.of(-0.84130859375);
+  private static final int kBackRightDriveMotorId = 5;
+  private static final int kBackRightSteerMotorId = 4;
+  private static final int kBackRightEncoderId = 2;
+  private static final Angle kBackRightEncoderOffset = Rotations.of(0.17236328125);
   private static final boolean kBackRightSteerMotorInverted = true;
-  private static final boolean kBackRightCANcoderInverted = false;
+  private static final boolean kBackRightEncoderInverted = false;
 
-  private static final Distance kBackRightXPos = Inches.of(-10.5);
-  private static final Distance kBackRightYPos = Inches.of(-10.5);
+  private static final Distance kBackRightXPos = Inches.of(-10);
+  private static final Distance kBackRightYPos = Inches.of(-10);
 
-  public static final SwerveModuleConstants FrontLeft =
-      ConstantCreator.createModuleConstants(
-          kFrontLeftSteerMotorId,
-          kFrontLeftDriveMotorId,
-          kFrontLeftEncoderId,
-          kFrontLeftEncoderOffset,
-          kFrontLeftXPos,
-          kFrontLeftYPos,
-          kInvertLeftSide,
-          kFrontLeftSteerMotorInverted,
-          kFrontLeftCANcoderInverted);
-  public static final SwerveModuleConstants FrontRight =
-      ConstantCreator.createModuleConstants(
-          kFrontRightSteerMotorId,
-          kFrontRightDriveMotorId,
-          kFrontRightEncoderId,
-          kFrontRightEncoderOffset,
-          kFrontRightXPos,
-          kFrontRightYPos,
-          kInvertRightSide,
-          kFrontRightSteerMotorInverted,
-          kFrontRightCANcoderInverted);
-  public static final SwerveModuleConstants BackLeft =
-      ConstantCreator.createModuleConstants(
-          kBackLeftSteerMotorId,
-          kBackLeftDriveMotorId,
-          kBackLeftEncoderId,
-          kBackLeftEncoderOffset,
-          kBackLeftXPos,
-          kBackLeftYPos,
-          kInvertLeftSide,
-          kBackLeftSteerMotorInverted,
-          kBackLeftCANcoderInverted);
-  public static final SwerveModuleConstants BackRight =
-      ConstantCreator.createModuleConstants(
-          kBackRightSteerMotorId,
-          kBackRightDriveMotorId,
-          kBackRightEncoderId,
-          kBackRightEncoderOffset,
-          kBackRightXPos,
-          kBackRightYPos,
-          kInvertRightSide,
-          kBackRightSteerMotorInverted,
-          kBackRightCANcoderInverted);
+  public static final SwerveModuleConstants<
+          TalonFXConfiguration, TalonFXConfiguration, CANcoderConfiguration>
+      FrontLeft =
+          ConstantCreator.createModuleConstants(
+              kFrontLeftSteerMotorId,
+              kFrontLeftDriveMotorId,
+              kFrontLeftEncoderId,
+              kFrontLeftEncoderOffset,
+              kFrontLeftXPos,
+              kFrontLeftYPos,
+              kInvertLeftSide,
+              kFrontLeftSteerMotorInverted,
+              kFrontLeftEncoderInverted);
+  public static final SwerveModuleConstants<
+          TalonFXConfiguration, TalonFXConfiguration, CANcoderConfiguration>
+      FrontRight =
+          ConstantCreator.createModuleConstants(
+              kFrontRightSteerMotorId,
+              kFrontRightDriveMotorId,
+              kFrontRightEncoderId,
+              kFrontRightEncoderOffset,
+              kFrontRightXPos,
+              kFrontRightYPos,
+              kInvertRightSide,
+              kFrontRightSteerMotorInverted,
+              kFrontRightEncoderInverted);
+  public static final SwerveModuleConstants<
+          TalonFXConfiguration, TalonFXConfiguration, CANcoderConfiguration>
+      BackLeft =
+          ConstantCreator.createModuleConstants(
+              kBackLeftSteerMotorId,
+              kBackLeftDriveMotorId,
+              kBackLeftEncoderId,
+              kBackLeftEncoderOffset,
+              kBackLeftXPos,
+              kBackLeftYPos,
+              kInvertLeftSide,
+              kBackLeftSteerMotorInverted,
+              kBackLeftEncoderInverted);
+  public static final SwerveModuleConstants<
+          TalonFXConfiguration, TalonFXConfiguration, CANcoderConfiguration>
+      BackRight =
+          ConstantCreator.createModuleConstants(
+              kBackRightSteerMotorId,
+              kBackRightDriveMotorId,
+              kBackRightEncoderId,
+              kBackRightEncoderOffset,
+              kBackRightXPos,
+              kBackRightYPos,
+              kInvertRightSide,
+              kBackRightSteerMotorInverted,
+              kBackRightEncoderInverted);
 
   /**
    * Creates a CommandSwerveDrivetrain instance. This should only be called once in your robot
@@ -224,5 +241,78 @@ public class TunerConstants {
   public static CommandSwerveDrivetrain createDrivetrain() {
     return new CommandSwerveDrivetrain(
         DrivetrainConstants, FrontLeft, FrontRight, BackLeft, BackRight);
+  }
+
+  /** Swerve Drive class utilizing CTR Electronics' Phoenix 6 API with the selected device types. */
+  public static class TunerSwerveDrivetrain extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder> {
+    /**
+     * Constructs a CTRE SwerveDrivetrain using the specified constants.
+     *
+     * <p>This constructs the underlying hardware devices, so users should not construct the devices
+     * themselves. If they need the devices, they can access them through getters in the classes.
+     *
+     * @param drivetrainConstants Drivetrain-wide constants for the swerve drive
+     * @param modules Constants for each specific module
+     */
+    public TunerSwerveDrivetrain(
+        SwerveDrivetrainConstants drivetrainConstants, SwerveModuleConstants<?, ?, ?>... modules) {
+      super(TalonFX::new, TalonFX::new, CANcoder::new, drivetrainConstants, modules);
+    }
+
+    /**
+     * Constructs a CTRE SwerveDrivetrain using the specified constants.
+     *
+     * <p>This constructs the underlying hardware devices, so users should not construct the devices
+     * themselves. If they need the devices, they can access them through getters in the classes.
+     *
+     * @param drivetrainConstants Drivetrain-wide constants for the swerve drive
+     * @param odometryUpdateFrequency The frequency to run the odometry loop. If unspecified or set
+     *     to 0 Hz, this is 250 Hz on CAN FD, and 100 Hz on CAN 2.0.
+     * @param modules Constants for each specific module
+     */
+    public TunerSwerveDrivetrain(
+        SwerveDrivetrainConstants drivetrainConstants,
+        double odometryUpdateFrequency,
+        SwerveModuleConstants<?, ?, ?>... modules) {
+      super(
+          TalonFX::new,
+          TalonFX::new,
+          CANcoder::new,
+          drivetrainConstants,
+          odometryUpdateFrequency,
+          modules);
+    }
+
+    /**
+     * Constructs a CTRE SwerveDrivetrain using the specified constants.
+     *
+     * <p>This constructs the underlying hardware devices, so users should not construct the devices
+     * themselves. If they need the devices, they can access them through getters in the classes.
+     *
+     * @param drivetrainConstants Drivetrain-wide constants for the swerve drive
+     * @param odometryUpdateFrequency The frequency to run the odometry loop. If unspecified or set
+     *     to 0 Hz, this is 250 Hz on CAN FD, and 100 Hz on CAN 2.0.
+     * @param odometryStandardDeviation The standard deviation for odometry calculation in the form
+     *     [x, y, theta]ᵀ, with units in meters and radians
+     * @param visionStandardDeviation The standard deviation for vision calculation in the form [x,
+     *     y, theta]ᵀ, with units in meters and radians
+     * @param modules Constants for each specific module
+     */
+    public TunerSwerveDrivetrain(
+        SwerveDrivetrainConstants drivetrainConstants,
+        double odometryUpdateFrequency,
+        Matrix<N3, N1> odometryStandardDeviation,
+        Matrix<N3, N1> visionStandardDeviation,
+        SwerveModuleConstants<?, ?, ?>... modules) {
+      super(
+          TalonFX::new,
+          TalonFX::new,
+          CANcoder::new,
+          drivetrainConstants,
+          odometryUpdateFrequency,
+          odometryStandardDeviation,
+          visionStandardDeviation,
+          modules);
+    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/PhotonvisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PhotonvisionSubsystem.java
@@ -4,6 +4,7 @@ import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
+import java.util.List;
 import java.util.Optional;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
@@ -22,27 +23,30 @@ public class PhotonvisionSubsystem {
     this.robotToCam = new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0, 0, 0));
     this.poseEstimator =
         new PhotonPoseEstimator(
-            AprilTagFields.k2024Crescendo.loadAprilTagLayoutField(),
+            AprilTagFields.k2024Crescendo
+                .loadAprilTagLayoutField(), // TODO deprecated please update
             PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
             robotToCam);
   }
 
   public Optional<EstimatedRobotPose> getEstimatedGlobalPose() {
-    return poseEstimator.update(getLatestResult());
+    return null;
+    // return poseEstimator.update(getLatestResults());
+    // TODO: the getLatestResult() now returns a list whcih is up to 20 PhotonPipelineResults from a
+    // FIFO queue, figure out how to update the pose for every missed one and return the most
+    // updated pose, maybe pass in a pose
   }
 
-  public PhotonPipelineResult getLatestResult() {
-    return camera.getLatestResult();
+  public List<PhotonPipelineResult> getLatestResults() {
+    return camera.getAllUnreadResults();
   }
 
   public boolean hasTargets() {
-    return getLatestResult().hasTargets();
+    return getLatestResults().size() != 0 ? getLatestResults().get(0).hasTargets() : false;
   }
 
   public PhotonTrackedTarget getBestTarget() {
-    if (hasTargets()) {
-      return getLatestResult().getBestTarget();
-    }
+    if (hasTargets()) return getLatestResults().get(0).getBestTarget();
     return null;
   }
 

--- a/src/main/java/frc/robot/subsystems/drivetrain/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/CommandSwerveDrivetrain.java
@@ -4,7 +4,6 @@ import static edu.wpi.first.units.Units.*;
 
 import com.ctre.phoenix6.SignalLogger;
 import com.ctre.phoenix6.Utils;
-import com.ctre.phoenix6.swerve.SwerveDrivetrain;
 import com.ctre.phoenix6.swerve.SwerveDrivetrainConstants;
 import com.ctre.phoenix6.swerve.SwerveModuleConstants;
 import com.ctre.phoenix6.swerve.SwerveRequest;
@@ -27,13 +26,14 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Subsystem;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
+import frc.robot.constants.TunerConstants.TunerSwerveDrivetrain;
 import java.util.function.Supplier;
 
 /**
  * Class that extends the Phoenix 6 SwerveDrivetrain class and implements Subsystem so it can easily
  * be used in command-based projects.
  */
-public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsystem {
+public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Subsystem {
   private static final double kSimLoopPeriod = 0.005; // 5 ms
   private Notifier m_simNotifier = null;
   private double m_lastSimTime;
@@ -49,8 +49,6 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
   private final SwerveRequest.ApplyRobotSpeeds m_pathApplyRobotSpeeds =
       new SwerveRequest.ApplyRobotSpeeds();
 
-  private final Field2d field = new Field2d();
-
   /* Swerve requests to apply during SysId characterization */
   private final SwerveRequest.SysIdSwerveTranslation m_translationCharacterization =
       new SwerveRequest.SysIdSwerveTranslation();
@@ -58,6 +56,8 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
       new SwerveRequest.SysIdSwerveSteerGains();
   private final SwerveRequest.SysIdSwerveRotation m_rotationCharacterization =
       new SwerveRequest.SysIdSwerveRotation();
+
+  private final Field2d field = new Field2d();
 
   /*
    * SysId routine for characterizing translation. This is used to find PID gains
@@ -129,7 +129,7 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
    * @param modules Constants for each specific module
    */
   public CommandSwerveDrivetrain(
-      SwerveDrivetrainConstants drivetrainConstants, SwerveModuleConstants... modules) {
+      SwerveDrivetrainConstants drivetrainConstants, SwerveModuleConstants<?, ?, ?>... modules) {
     super(drivetrainConstants, modules);
     if (Utils.isSimulation()) {
       startSimThread();
@@ -150,9 +150,9 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
    */
   public CommandSwerveDrivetrain(
       SwerveDrivetrainConstants drivetrainConstants,
-      double OdometryUpdateFrequency,
-      SwerveModuleConstants... modules) {
-    super(drivetrainConstants, OdometryUpdateFrequency, modules);
+      double odometryUpdateFrequency,
+      SwerveModuleConstants<?, ?, ?>... modules) {
+    super(drivetrainConstants, odometryUpdateFrequency, modules);
     if (Utils.isSimulation()) {
       startSimThread();
     }
@@ -168,8 +168,10 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
    * @param drivetrainConstants Drivetrain-wide constants for the swerve drive
    * @param odometryUpdateFrequency The frequency to run the odometry loop. If unspecified or set to
    *     0 Hz, this is 250 Hz on CAN FD, and 100 Hz on CAN 2.0.
-   * @param odometryStandardDeviation The standard deviation for odometry calculation
-   * @param visionStandardDeviation The standard deviation for vision calculation
+   * @param odometryStandardDeviation The standard deviation for odometry calculation in the form
+   *     [x, y, theta]ᵀ, with units in meters and radians
+   * @param visionStandardDeviation The standard deviation for vision calculation in the form [x, y,
+   *     theta]ᵀ, with units in meters and radians
    * @param modules Constants for each specific module
    */
   public CommandSwerveDrivetrain(
@@ -177,7 +179,7 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
       double odometryUpdateFrequency,
       Matrix<N3, N1> odometryStandardDeviation,
       Matrix<N3, N1> visionStandardDeviation,
-      SwerveModuleConstants... modules) {
+      SwerveModuleConstants<?, ?, ?>... modules) {
     super(
         drivetrainConstants,
         odometryUpdateFrequency,

--- a/vendordeps/Phoenix6-frc2025-latest.json
+++ b/vendordeps/Phoenix6-frc2025-latest.json
@@ -1,32 +1,32 @@
 {
-    "fileName": "Phoenix6-25.0.0-beta-4.json",
+    "fileName": "Phoenix6-frc2025-latest.json",
     "name": "CTRE-Phoenix (v6)",
-    "version": "25.0.0-beta-4",
+    "version": "25.1.0",
     "frcYear": "2025",
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
         "https://maven.ctr-electronics.com/release/"
     ],
-    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2025-beta-latest.json",
+    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2025-latest.json",
     "conflictsWith": [
         {
             "uuid": "e7900d8d-826f-4dca-a1ff-182f658e98af",
             "errorMessage": "Users can not have both the replay and regular Phoenix 6 vendordeps in their robot program.",
-            "offlineFileName": "Phoenix6-replay-frc2025-beta-latest.json"
+            "offlineFileName": "Phoenix6-replay-frc2025-latest.json"
         }
     ],
     "javaDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "25.0.0-beta-4"
+            "version": "25.1.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "api-cpp",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -40,7 +40,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -54,7 +54,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "api-cpp-sim",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -68,7 +68,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -82,7 +82,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -96,7 +96,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -124,7 +124,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -138,7 +138,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -152,21 +152,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "25.0.0-beta-4",
-            "isJar": false,
-            "skipInvalidPlatforms": true,
-            "validPlatforms": [
-                "windowsx86-64",
-                "linuxx86-64",
-                "linuxarm64",
-                "osxuniversal"
-            ],
-            "simMode": "swsim"
-        },
-        {
-            "groupId": "com.ctre.phoenix6.sim",
-            "artifactId": "simProCANrange",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -180,7 +166,21 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simProCANrange",
+            "version": "25.1.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -212,7 +212,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -228,7 +228,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -244,7 +244,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -260,7 +260,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -276,7 +276,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -292,7 +292,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -308,7 +308,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -324,7 +324,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -340,7 +340,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "25.0.0-beta-4",
+            "version": "25.1.0",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -355,9 +355,9 @@
         },
         {
             "groupId": "com.ctre.phoenix6.sim",
-            "artifactId": "simProCANrange",
-            "version": "25.0.0-beta-4",
-            "libName": "CTRE_SimProCANrange",
+            "artifactId": "simProPigeon2",
+            "version": "25.1.0",
+            "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,
             "skipInvalidPlatforms": true,
@@ -371,9 +371,9 @@
         },
         {
             "groupId": "com.ctre.phoenix6.sim",
-            "artifactId": "simProPigeon2",
-            "version": "25.0.0-beta-4",
-            "libName": "CTRE_SimProPigeon2",
+            "artifactId": "simProCANrange",
+            "version": "25.1.0",
+            "libName": "CTRE_SimProCANrange",
             "headerClassifier": "headers",
             "sharedLibrary": true,
             "skipInvalidPlatforms": true,

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "photonlib.json",
     "name": "photonlib",
-    "version": "v2025.0.0-beta-6",
+    "version": "v2025.0.0-beta-8",
     "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
     "frcYear": "2025",
     "mavenUrls": [
@@ -13,7 +13,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-cpp",
-            "version": "v2025.0.0-beta-6",
+            "version": "v2025.0.0-beta-8",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -28,7 +28,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-cpp",
-            "version": "v2025.0.0-beta-6",
+            "version": "v2025.0.0-beta-8",
             "libName": "photonlib",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -43,7 +43,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-cpp",
-            "version": "v2025.0.0-beta-6",
+            "version": "v2025.0.0-beta-8",
             "libName": "photontargeting",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -60,12 +60,12 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-java",
-            "version": "v2025.0.0-beta-6"
+            "version": "v2025.0.0-beta-8"
         },
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-java",
-            "version": "v2025.0.0-beta-6"
+            "version": "v2025.0.0-beta-8"
         }
     ]
 }


### PR DESCRIPTION
This pull request includes several updates to the `TunerConstants` and `PhotonvisionSubsystem` classes to improve functionality and accommodate new hardware configurations. The changes include updates to motor and encoder configurations, constants adjustments, and modifications to the Photonvision subsystem to handle a new result format.

### Updates to `TunerConstants`:

* **Motor and Encoder Configurations:**
  - Added new constants for `DriveMotorArrangement` and `SteerMotorArrangement` to specify motor types.
  - Updated initial configurations and renamed `CANcoderConfiguration` to `encoderInitialConfigs`.
  - Adjusted gear ratios and other constants to match new hardware specifications. [[1]](diffhunk://#diff-6e5b06cbd9a35399947543ba1861e21833f1cd76dd1ad19d75efd54494d8dc01L58-R63) [[2]](diffhunk://#diff-6e5b06cbd9a35399947543ba1861e21833f1cd76dd1ad19d75efd54494d8dc01L72-R93)

* **Module Constants Factory:**
  - Modified `SwerveModuleConstantsFactory` to include new motor and encoder types.
  - Updated module constants to use the new factory and added the new motor types.

* **Swerve Module Constants:**
  - Changed motor and encoder IDs and offsets for all four swerve modules. [[1]](diffhunk://#diff-6e5b06cbd9a35399947543ba1861e21833f1cd76dd1ad19d75efd54494d8dc01R129-R186) [[2]](diffhunk://#diff-6e5b06cbd9a35399947543ba1861e21833f1cd76dd1ad19d75efd54494d8dc01L185-R199)

* **New Swerve Drivetrain Class:**
  - Introduced `TunerSwerveDrivetrain` class to utilize the Phoenix 6 API with the specified device types.

### Updates to `PhotonvisionSubsystem`:

* **Result Handling:**
  - Updated the `getLatestResults` method to return a list of results instead of a single result.
  - Modified the `hasTargets` and `getBestTarget` methods to handle the new list-based result format.

### Other Changes:

* **Command Swerve Drivetrain:**
  - Updated `CommandSwerveDrivetrain` to extend `TunerSwerveDrivetrain` instead of `SwerveDrivetrain`.
  - Reorganized the `Field2d` instance initialization. [[1]](diffhunk://#diff-4931c3dbf6900c89af8f09a255f04e14b726458773700e8e7ca1aafc2e63f40eL52-L53) [[2]](diffhunk://#diff-4931c3dbf6900c89af8f09a255f04e14b726458773700e8e7ca1aafc2e63f40eR60-R61)