### PR TITLE
Reef Alignment Command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2025.1.1"
+    id "edu.wpi.first.GradleRIO" version "2025.2.1"
     id 'com.diffplug.spotless' version '6.25.0'
 }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -10,6 +10,7 @@ import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.swerve.SwerveRequest;
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.commands.PathPlannerAuto;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -21,6 +22,7 @@ import frc.robot.commands.ToPose;
 import frc.robot.constants.Constants;
 import frc.robot.constants.Constants.CameraConfig;
 import frc.robot.constants.Constants.DrivetrainConstants;
+import frc.robot.constants.Constants.ScoringConstants;
 import frc.robot.constants.Constants.VisionConstants;
 import frc.robot.constants.TunerConstants;
 import frc.robot.subsystems.PhotonvisionSubsystem;
@@ -29,6 +31,7 @@ import frc.robot.subsystems.elevator.ElevatorSubsystem;
 import frc.robot.subsystems.wrist.WristSubsystem;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class RobotContainer {
   private double MaxSpeed = DrivetrainConstants.kMaxVelocity.in(MetersPerSecond);
@@ -79,6 +82,18 @@ public class RobotContainer {
     // antiTip.schedule();
   }
 
+  private enum ScoringHeights {
+    L1,
+    L2,
+    L3,
+    L4
+  }
+
+  private enum ScoringPosition {
+    LEFT,
+    RIGHT
+  }
+
   private final Command elevatorToL1 =
       elevator.setPosition(Meters.of(Constants.ScoringConstants.elevatorSetPointL1));
   private final Command elevatorToL2 =
@@ -99,6 +114,35 @@ public class RobotContainer {
   private final Command scoreL2 = new ParallelCommandGroup(elevatorToL2, wristL2);
   private final Command scoreL3 = new ParallelCommandGroup(elevatorToL3, wristL3);
   private final Command scoreL4 = new ParallelCommandGroup(elevatorToL4, wristL4);
+
+  private Command alignToReef(ScoringPosition position) {
+    Pose2d robotPose2d = drivetrain.getState().Pose;
+
+    Map<Integer, Pose2d> reefPoseMap = ScoringConstants.reefPoseMap;
+
+    int closestTagId = -1;
+    double minDistance = Double.MAX_VALUE;
+    Pose2d closestPose = null;
+
+    for (Map.Entry<Integer, Pose2d> entry : reefPoseMap.entrySet()) {
+      int tagId = entry.getKey();
+      Pose2d tagPose = entry.getValue();
+
+      double distance = robotPose2d.getTranslation().getDistance(tagPose.getTranslation());
+
+      if (distance < minDistance) {
+        minDistance = distance;
+        closestTagId = tagId;
+        closestPose = tagPose;
+      }
+    }
+
+    SmartDashboard.putNumber("Closest Reef Side", closestTagId);
+    SmartDashboard.putNumber("Closest Reef Pose/x", closestPose.getX());
+    SmartDashboard.putNumber("Closest Reef Pose/y", closestPose.getY());
+
+    return null;
+  }
 
   private void configureBindings() {
     // Note that X is defined as forward according to WPILib convention,

--- a/src/main/java/frc/robot/commands/AlignToReef.java
+++ b/src/main/java/frc/robot/commands/AlignToReef.java
@@ -1,0 +1,138 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+
+import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
+import com.ctre.phoenix6.swerve.SwerveRequest;
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.constants.Constants.DrivetrainConstants;
+import frc.robot.constants.Constants.ScoringConstants;
+import frc.robot.constants.Constants.ScoringConstants.ScoringPosition;
+import frc.robot.subsystems.drivetrain.CommandSwerveDrivetrain;
+import java.util.Map;
+
+public class AlignToReef extends Command {
+  private final CommandSwerveDrivetrain drivetrain;
+  private final ScoringPosition scoringPosition;
+  private Pose2d targetPose;
+
+  private double MaxSpeed = DrivetrainConstants.kMaxVelocity.in(MetersPerSecond);
+  private double MaxAngularRate = DrivetrainConstants.kMaxAngularRate.in(RotationsPerSecond);
+
+  private final PIDController pidX = DrivetrainConstants.kPoseVelocityXController;
+  private final PIDController pidY = DrivetrainConstants.kPoseVelocityYController;
+  private final PIDController pidTheta = DrivetrainConstants.kPoseThetaController;
+
+  private final SwerveRequest.FieldCentric drive =
+      new SwerveRequest.FieldCentric()
+          .withDeadband(MaxSpeed * 0.05)
+          .withRotationalDeadband(MaxAngularRate * 0.05)
+          .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+
+  /** Creates a new AlignToReef command. */
+  public AlignToReef(CommandSwerveDrivetrain drivetrain, ScoringPosition scoringPosition) {
+    this.drivetrain = drivetrain;
+    this.scoringPosition = scoringPosition;
+    addRequirements(drivetrain);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    Pose2d robotPose = drivetrain.getState().Pose;
+    SmartDashboard.putString("Current Robot Pose", robotPose.toString());
+
+    Map<Integer, Pose2d> reefPoseMap = ScoringConstants.reefPoseMap;
+
+    int closestTagId = -1;
+    double minDistance = Double.MAX_VALUE;
+    Pose2d closestPose = null;
+    for (Map.Entry<Integer, Pose2d> entry : reefPoseMap.entrySet()) {
+      int tagId = entry.getKey();
+      Pose2d tagPose = entry.getValue();
+      double distance = robotPose.getTranslation().getDistance(tagPose.getTranslation());
+      if (distance < minDistance) {
+        minDistance = distance;
+        closestTagId = tagId;
+        closestPose = tagPose;
+      }
+    }
+    SmartDashboard.putNumber("Closest Reef Tag", closestTagId);
+
+    if (closestPose == null) {
+      System.err.println("No valid reef tag pose available!");
+      return;
+    }
+
+    if (scoringPosition == ScoringPosition.LEFT) {
+      targetPose =
+          closestPose.transformBy(
+              new Transform2d(ScoringConstants.leftReefOffset, new Rotation2d()));
+    } else {
+      targetPose =
+          closestPose.transformBy(
+              new Transform2d(ScoringConstants.rightReefOffset, new Rotation2d()));
+    }
+    SmartDashboard.putNumberArray(
+        "Target Robot Reef Pose",
+        new double[] {targetPose.getX(), targetPose.getY(), targetPose.getRotation().getDegrees()});
+
+    pidX.setTolerance(0.01);
+    pidY.setTolerance(0.01);
+    pidTheta.setTolerance(Units.degreesToRadians(0.1));
+
+    pidTheta.enableContinuousInput(-Math.PI, Math.PI);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    Pose2d currentPose = drivetrain.getState().Pose;
+
+    double vx = pidX.calculate(currentPose.getX(), targetPose.getX());
+    double vy = pidY.calculate(currentPose.getY(), targetPose.getY());
+    double omega =
+        pidTheta.calculate(
+            currentPose.getRotation().getRadians(), targetPose.getRotation().getRadians());
+
+    vx = MathUtil.clamp(vx, -MaxSpeed, MaxSpeed);
+    vy = MathUtil.clamp(vy, -MaxSpeed, MaxSpeed);
+    // omega = MathUtil.clamp(omega, -MaxAngularRate, MaxAngularRate);
+
+    SmartDashboard.putNumber("PID vx", vx);
+    SmartDashboard.putNumber("PID vy", vy);
+    SmartDashboard.putNumber("PID omega", omega);
+
+    final double vxf = vx;
+    final double vyf = vy;
+    final double omegaf = omega;
+    drivetrain.setControl(drive.withVelocityX(-vxf).withVelocityY(-vyf).withRotationalRate(omegaf));
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    drivetrain.applyRequest(() -> drive.withVelocityX(0).withVelocityY(0).withRotationalRate(0));
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    boolean positionReached = pidX.atSetpoint() && pidY.atSetpoint();
+    boolean angleReached = pidTheta.atSetpoint();
+
+    return positionReached && angleReached;
+  }
+}

--- a/src/main/java/frc/robot/constants/Constants.java
+++ b/src/main/java/frc/robot/constants/Constants.java
@@ -13,10 +13,12 @@ import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
@@ -37,6 +39,9 @@ public class Constants {
   public static class DrivetrainConstants {
     public static final LinearVelocity kMaxVelocity = TunerConstants.kSpeedAt12Volts;
     public static final AngularVelocity kMaxAngularRate = RotationsPerSecond.of(3);
+    public static final PIDController kPoseVelocityXController = new PIDController(5, 0, 0);
+    public static final PIDController kPoseVelocityYController = new PIDController(5, 0, 0);
+    public static final PIDController kPoseThetaController = new PIDController(10, 0, 0);
   }
 
   public static class IntakeCoralConstants {
@@ -74,6 +79,28 @@ public class Constants {
     }
 
     public static Map<Integer, Pose2d> reefPoseMap = getReefPoseMap();
+
+    public static final Translation2d leftReefOffset =
+        new Translation2d(0.2286, 0.1651); // should probally be robot
+    // bumper
+    // offset to be flush and then the left
+    public static final Translation2d rightReefOffset =
+        new Translation2d(0.2286, -0.1651); // should probally be robot
+    // bumper
+    // offset to be flush and then the
+    // right
+
+    public enum ScoringHeights {
+      L1,
+      L2,
+      L3,
+      L4
+    }
+
+    public enum ScoringPosition {
+      LEFT,
+      RIGHT
+    }
   }
 
   public static class VisionConstants {

--- a/src/main/java/frc/robot/constants/Constants.java
+++ b/src/main/java/frc/robot/constants/Constants.java
@@ -13,12 +13,17 @@ import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.units.measure.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 public class Constants {
   public static class RobotConstants {
@@ -47,6 +52,28 @@ public class Constants {
     public static final double wristSetPointL3 = 0; // replace
     public static final double wristSetPointL2 = 0; // replace
     public static final double wristSetPointL1 = 0; // replace
+
+    public static int[] reefIds = {6, 7, 8, 9, 10, 11, 17, 18, 19, 20, 21, 22};
+
+    public static Map<Integer, Pose2d> getReefPoseMap() {
+      AprilTagFieldLayout fieldLayout =
+          AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+
+      Map<Integer, Pose2d> poseMap = new HashMap<>();
+
+      for (int tagId : reefIds) {
+        Optional<Pose3d> optionalPose = fieldLayout.getTagPose(tagId);
+
+        if (optionalPose.isPresent()) {
+          Pose2d pose = optionalPose.get().toPose2d();
+          poseMap.put(tagId, pose);
+        }
+      }
+
+      return poseMap;
+    }
+
+    public static Map<Integer, Pose2d> reefPoseMap = getReefPoseMap();
   }
 
   public static class VisionConstants {
@@ -55,7 +82,7 @@ public class Constants {
     public static final Matrix<N3, N1> kSingleTagStdDevs = VecBuilder.fill(3, 5, 7);
     public static final Matrix<N3, N1> kMultiTagStdDevs = VecBuilder.fill(0.5, 0.5, 1);
     public static final AprilTagFieldLayout kTagLayout =
-        AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
+        AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
     public static final Transform3d kRobotToCamTwo =
         new Transform3d(new Translation3d(-0.5, 0.1, 0.4), new Rotation3d(0, 0.34, 0));
   }


### PR DESCRIPTION
### New Command Implementation:
* Added the `AlignToReef` command to align the robot to specific scoring positions on the reef using PID controllers and pose transformations. (`src/main/java/frc/robot/commands/AlignToReef.java`)

### Constants Updates:
* Added PID controllers and reef pose mappings to `DrivetrainConstants` and `ScoringConstants` to support the new `AlignToReef` command. (`src/main/java/frc/robot/constants/Constants.java`)
* Updated the vision constants to use the `k2025Reefscape` field layout. (`src/main/java/frc/robot/constants/Constants.java`)

Used PID for reaching the pose instead of using PathPlanner because when the target poses are too close, the PathPlanner thinks the robot is already at the spot since it treats them as the same node when pathfinding.